### PR TITLE
Fix mobile filter scrolling on responsive views

### DIFF
--- a/client/src/components/clients-view-responsive.tsx
+++ b/client/src/components/clients-view-responsive.tsx
@@ -64,7 +64,7 @@ export default function ClientsView() {
   };
 
   return (
-    <>
+    <div className="flex flex-col h-full">
       {/* Mobile Header */}
       <header className="bg-white border-b border-gray-200 px-4 py-3 sm:px-6 sm:py-4">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -98,7 +98,7 @@ export default function ClientsView() {
       </header>
 
       {/* Main Content */}
-      <div className="flex-1 p-4 sm:p-6 overflow-y-auto">
+      <div className="flex-1 p-4 sm:p-6 overflow-y-auto max-w-full">
         {/* Collapsible Filters */}
         <Collapsible open={isFiltersOpen} onOpenChange={setIsFiltersOpen}>
           <CollapsibleTrigger asChild>
@@ -200,6 +200,6 @@ export default function ClientsView() {
           onSuccess={handleFormSuccess}
         />
       )}
-    </>
+    </div>
   );
 }

--- a/client/src/components/trajectories-view-responsive.tsx
+++ b/client/src/components/trajectories-view-responsive.tsx
@@ -138,7 +138,7 @@ export default function TrajectoriesView() {
   };
 
   return (
-    <>
+    <div className="flex flex-col h-full">
       {/* Mobile Header */}
       <header className="bg-white border-b border-gray-200 px-4 py-3 sm:px-6 sm:py-4">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
@@ -172,7 +172,7 @@ export default function TrajectoriesView() {
       </header>
 
       {/* Main Content */}
-      <div className="flex-1 p-4 sm:p-6 overflow-y-auto">
+      <div className="flex-1 p-4 sm:p-6 overflow-y-auto max-w-full">
         {/* Collapsible Filters */}
         <Collapsible open={isFiltersOpen} onOpenChange={setIsFiltersOpen}>
           <CollapsibleTrigger asChild>
@@ -336,6 +336,6 @@ export default function TrajectoriesView() {
           }}
         />
       )}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap trajectories and clients responsive pages in full-height flex containers to restore scrolling
- Ensure main content areas use `overflow-y-auto` with `max-w-full` for proper mobile scroll behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Declaration or statement expected in client-detail-backup.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a867dd8da0832daf44372f1752a5aa