### PR TITLE
Prevent duplicate candidates by name or email

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -637,29 +637,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const { trajectories, notes, ...candidateData } = req.body;
       const validatedCandidateData = insertCandidateSchema.parse(candidateData);
       
-      // Check for duplicates
+      // Check for duplicate email
       if (validatedCandidateData.email) {
         const existingByEmail = await storage.getCandidateByEmail(validatedCandidateData.email);
         if (existingByEmail) {
-          return res.status(400).json({ 
+          return res.status(400).json({
             message: "Een kandidaat met dit emailadres bestaat al",
-            duplicate: existingByEmail 
+            duplicate: existingByEmail
           });
         }
       }
-      
-      // Check for name + phone combination if no email
-      if (!validatedCandidateData.email && validatedCandidateData.phone) {
-        const existingByNamePhone = await storage.getCandidateByNameAndPhone(
-          validatedCandidateData.name, 
-          validatedCandidateData.phone
-        );
-        if (existingByNamePhone) {
-          return res.status(400).json({ 
-            message: "Een kandidaat met deze naam en telefoonnummer bestaat al",
-            duplicate: existingByNamePhone 
-          });
-        }
+
+      // Always check for duplicate name
+      const existingByName = await storage.getCandidateByName(validatedCandidateData.name);
+      if (existingByName) {
+        return res.status(400).json({
+          message: "Een kandidaat met deze naam bestaat al",
+          duplicate: existingByName
+        });
       }
       
       // Normaliseer rijbewijs data als aanwezig
@@ -863,13 +858,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
               continue;
             }
           }
-          
-          if (!candidateData.email && candidateData.phone) {
-            const existingByNamePhone = await storage.getCandidateByNameAndPhone(candidateData.name, candidateData.phone);
-            if (existingByNamePhone) {
-              errors.push(`Rij ${index + 2}: Kandidaat '${candidateData.name}' met telefoon '${candidateData.phone}' bestaat al`);
-              continue;
-            }
+
+          const existingByName = await storage.getCandidateByName(candidateData.name);
+          if (existingByName) {
+            errors.push(`Rij ${index + 2}: Kandidaat '${candidateData.name}' bestaat al`);
+            continue;
           }
 
           // Validate and create candidate

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -128,6 +128,7 @@ export interface IStorage {
   logAudit(entityType: string, entityId: number, action: string, changes: any, userId: string): Promise<void>;
 
   getCandidateByEmail(email: string): Promise<Candidate | null>;
+  getCandidateByName(name: string): Promise<Candidate | null>;
   getCandidateByNameAndPhone(name: string, phone: string): Promise<Candidate | null>;
 }
 
@@ -381,6 +382,20 @@ export class DatabaseStorage implements IStorage {
       return candidate || null;
     } catch (error) {
       console.error("Error getting candidate by email:", error);
+      return null;
+    }
+  }
+
+  async getCandidateByName(name: string): Promise<Candidate | null> {
+    try {
+      const [candidate] = await db
+        .select()
+        .from(candidates)
+        .where(eq(candidates.name, name))
+        .limit(1);
+      return candidate || null;
+    } catch (error) {
+      console.error("Error getting candidate by name:", error);
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- check for existing candidate by email and by name when creating
- extend import routine to validate name duplicates
- add storage helper to look up candidates by name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: client/src/pages/client-detail-backup.tsx: Declaration or statement expected)*

------
https://chatgpt.com/codex/tasks/task_e_68a86d064374832d8090a8b815b46e4b