### PR TITLE
Use phase column for candidate status options

### DIFF
--- a/client/src/components/NewCandidateModal.tsx
+++ b/client/src/components/NewCandidateModal.tsx
@@ -34,7 +34,6 @@ export default function NewCandidateModal({ isOpen, onClose }: NewCandidateModal
       region: "",
       marketing: "",
       description: "",
-      status: "active",
       phase: "intake",
       drivingLicenses: [],
     },
@@ -74,8 +73,9 @@ export default function NewCandidateModal({ isOpen, onClose }: NewCandidateModal
   const onSubmit = (data: InsertCandidate) => {
     const candidateData = {
       ...data,
-      drivingLicenses: drivingLicenses
-    };
+      drivingLicenses: drivingLicenses,
+    } as any;
+    delete candidateData.status;
     createCandidateMutation.mutate(candidateData);
   };
 
@@ -142,40 +142,59 @@ export default function NewCandidateModal({ isOpen, onClose }: NewCandidateModal
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="region">Regio</Label>
-              <Select onValueChange={(value) => form.setValue("region", value)}>
-                <SelectTrigger className="mt-1">
-                  <SelectValue placeholder="Selecteer regio" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="Noord-Holland">Noord-Holland</SelectItem>
-                  <SelectItem value="Zuid-Holland">Zuid-Holland</SelectItem>
-                  <SelectItem value="Utrecht">Utrecht</SelectItem>
-                  <SelectItem value="Gelderland">Gelderland</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label htmlFor="marketing">Marketing Bron</Label>
-              <Select onValueChange={(value) => form.setValue("marketing", value)}>
-                <SelectTrigger className="mt-1">
-                  <SelectValue placeholder="Selecteer bron" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="linkedin">LinkedIn</SelectItem>
-                  <SelectItem value="indeed">Indeed</SelectItem>
-                  <SelectItem value="referral">Doorverwijzing</SelectItem>
-                  <SelectItem value="website">Website</SelectItem>
-                  <SelectItem value="other">Anders</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
+        <div className="grid grid-cols-2 gap-4">
           <div>
-            <Label className="text-sm font-medium text-gray-700 mb-2 block">Rijbewijs</Label>
+            <Label htmlFor="region">Regio</Label>
+            <Select onValueChange={(value) => form.setValue("region", value)}>
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="Selecteer regio" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Noord-Holland">Noord-Holland</SelectItem>
+                <SelectItem value="Zuid-Holland">Zuid-Holland</SelectItem>
+                <SelectItem value="Utrecht">Utrecht</SelectItem>
+                <SelectItem value="Gelderland">Gelderland</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="phase">Status</Label>
+            <Select
+              value={form.watch("phase")}
+              onValueChange={(value) => form.setValue("phase", value)}
+            >
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="Selecteer status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="intake">Intake</SelectItem>
+                <SelectItem value="matching">Matching</SelectItem>
+                <SelectItem value="placed">Geplaatst</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4">
+          <div>
+            <Label htmlFor="marketing">Marketing Bron</Label>
+            <Select onValueChange={(value) => form.setValue("marketing", value)}>
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="Selecteer bron" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="linkedin">LinkedIn</SelectItem>
+                <SelectItem value="indeed">Indeed</SelectItem>
+                <SelectItem value="referral">Doorverwijzing</SelectItem>
+                <SelectItem value="website">Website</SelectItem>
+                <SelectItem value="other">Anders</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div>
+          <Label className="text-sm font-medium text-gray-700 mb-2 block">Rijbewijs</Label>
             <div className="grid grid-cols-3 gap-4">
               {[
                 'A', 'AM', 'B', 'BE', 'C', 'CE', 'D', 'DE', 'T'

--- a/client/src/components/candidate-form.tsx
+++ b/client/src/components/candidate-form.tsx
@@ -67,7 +67,6 @@ export default function CandidateForm({ candidate, onClose, onSuccess }: Candida
       region: candidate?.region || "",
       marketing: candidate?.marketing || "",
       description: candidate?.description || "",
-      status: candidate?.status || "active",
       phase: candidate?.phase || "intake",
       drivingLicenses: candidate?.drivingLicenses || [],
       drivingLicenseNotes: candidate?.drivingLicenseNotes || "",
@@ -148,6 +147,7 @@ export default function CandidateForm({ candidate, onClose, onSuccess }: Candida
       marketing: data.marketing || null,
       description: data.description || null,
     };
+    delete cleanedData.status;
 
     if (isEditing) {
       updateMutation.mutate(cleanedData);
@@ -362,23 +362,26 @@ export default function CandidateForm({ candidate, onClose, onSuccess }: Candida
                 />
                 <FormField
                   control={form.control}
-                  name="status"
+                  name="phase"
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>Status</FormLabel>
-                      <Select onValueChange={(value) => field.onChange(value === "clear" ? "" : value)} defaultValue={field.value || ""}>
+                      <Select
+                        onValueChange={(value) => field.onChange(value === "clear" ? "" : value)}
+                        defaultValue={field.value || ""}
+                      >
                         <FormControl>
                           <SelectTrigger>
-                            <SelectValue />
+                            <SelectValue placeholder="Selecteer status" />
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>
                           <SelectItem value="clear">
                             <span className="text-muted-foreground italic">Geen selectie</span>
                           </SelectItem>
-                          <SelectItem value="active">Actief</SelectItem>
+                          <SelectItem value="intake">Intake</SelectItem>
+                          <SelectItem value="matching">Matching</SelectItem>
                           <SelectItem value="placed">Geplaatst</SelectItem>
-                          <SelectItem value="inactive">Inactief</SelectItem>
                         </SelectContent>
                       </Select>
                       <FormMessage />
@@ -387,37 +390,7 @@ export default function CandidateForm({ candidate, onClose, onSuccess }: Candida
                 />
               </div>
 
-              <div className={`grid gap-4 ${isEditing ? "grid-cols-1" : "grid-cols-2"}`}>
-                {!isEditing && (
-                  <FormField
-                    control={form.control}
-                    name="phase"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Fase</FormLabel>
-                        <Select
-                          onValueChange={(value) => field.onChange(value === "clear" ? "" : value)}
-                          defaultValue={field.value || ""}
-                        >
-                          <FormControl>
-                            <SelectTrigger>
-                              <SelectValue placeholder="Selecteer fase" />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            <SelectItem value="clear">
-                              <span className="text-muted-foreground italic">Geen selectie</span>
-                            </SelectItem>
-                            <SelectItem value="intake">Intake</SelectItem>
-                            <SelectItem value="matching">Matching</SelectItem>
-                            <SelectItem value="placed">Geplaatst</SelectItem>
-                          </SelectContent>
-                        </Select>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                )}
+              <div className="grid gap-4 grid-cols-1">
                 <FormField
                   control={form.control}
                   name="marketing"


### PR DESCRIPTION
## Summary
- Replace candidate status dropdown with phase-based options in add/edit form
- Show phase values in status selector when adding new candidates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a87e3e3760832d8c0b8546a264c369