### PR TITLE
Replace candidate status column usage with phase

### DIFF
--- a/client/src/components/CandidatesList.tsx
+++ b/client/src/components/CandidatesList.tsx
@@ -40,7 +40,7 @@ export default function CandidatesList() {
       candidate.city?.toLowerCase().includes(filters.search.toLowerCase());
 
     // Status filter
-    const matchesStatus = filters.selectedStatuses.length === 0 || filters.selectedStatuses.includes(candidate.status);
+    const matchesPhase = filters.selectedPhases.length === 0 || filters.selectedPhases.includes(candidate.phase);
 
     // Region filter
     const matchesRegion = filters.selectedRegion === "" || filters.selectedRegion === "alle" || candidate.region === filters.selectedRegion;
@@ -51,7 +51,7 @@ export default function CandidatesList() {
         candidate.drivingLicenses.includes(license)
       ));
 
-    return matchesSearch && matchesStatus && matchesRegion && matchesLicense;
+    return matchesSearch && matchesPhase && matchesRegion && matchesLicense;
   }).sort((a: any, b: any) => {
     let aValue, bValue;
     
@@ -71,7 +71,7 @@ export default function CandidatesList() {
   });
 
   // Extract filter options from data
-  const statusOptions = Array.from(new Set(candidatesArray.map((c: any) => c.status).filter(Boolean)));
+  const phaseOptions = Array.from(new Set(candidatesArray.map((c: any) => c.phase).filter(Boolean)));
   const regionOptions = Array.from(new Set(candidatesArray.map((c: any) => c.region).filter(Boolean)));
   const licenseOptions = ['A', 'AM', 'B', 'BE', 'C', 'CE', 'D', 'DE', 'T'];
 
@@ -84,7 +84,7 @@ export default function CandidatesList() {
   };
 
   const activeFiltersCount = 
-    filters.selectedStatuses.length + 
+    filters.selectedPhases.length +
     (filters.selectedRegion ? 1 : 0) + 
     filters.selectedLicenses.length +
     (filters.search ? 1 : 0);
@@ -155,27 +155,27 @@ export default function CandidatesList() {
           </CollapsibleTrigger>
           <CollapsibleContent className="space-y-4 mb-6 p-4 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-              {/* Status Filter */}
+              {/* Phase Filter */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Status
+                  Fase
                 </label>
                 <div className="space-y-2">
-                  {statusOptions.map((status) => (
-                    <div key={status} className="flex items-center space-x-2">
+                  {phaseOptions.map((phase) => (
+                    <div key={phase} className="flex items-center space-x-2">
                       <Checkbox
-                        id={`status-${status}`}
-                        checked={filters.selectedStatuses.includes(status)}
+                        id={`status-${phase}`}
+                        checked={filters.selectedPhases.includes(phase)}
                         onCheckedChange={(checked) => {
                           if (checked) {
-                            updateFilters({ selectedStatuses: [...filters.selectedStatuses, status] });
+                            updateFilters({ selectedPhases: [...filters.selectedPhases, phase] });
                           } else {
-                            updateFilters({ selectedStatuses: filters.selectedStatuses.filter(s => s !== status) });
+                            updateFilters({ selectedPhases: filters.selectedPhases.filter(s => s !== phase) });
                           }
                         }}
                       />
-                      <Label htmlFor={`status-${status}`} className="text-sm">
-                        {status}
+                      <Label htmlFor={`status-${phase}`} className="text-sm">
+                        {phase}
                       </Label>
                     </div>
                   ))}
@@ -294,9 +294,9 @@ export default function CandidatesList() {
                         Zoekterm: "{filters.search}"
                       </Badge>
                     )}
-                    {filters.selectedStatuses.map(status => (
-                      <Badge key={status} variant="outline" className="text-xs bg-white border-green-300 text-green-700">
-                        Status: {status}
+                    {filters.selectedPhases.map(phase => (
+                      <Badge key={phase} variant="outline" className="text-xs bg-white border-green-300 text-green-700">
+                        Fase: {phase}
                       </Badge>
                     ))}
                     {filters.selectedRegion && (

--- a/client/src/components/FilterPanel.tsx
+++ b/client/src/components/FilterPanel.tsx
@@ -11,7 +11,7 @@ import { useQuery } from "@tanstack/react-query";
 
 interface FilterPanelProps {
   onFiltersChange: (filters: {
-    status: string[];
+    phase: string[];
     region: string;
     drivingLicense: string[];
     dateFrom: string;
@@ -21,7 +21,7 @@ interface FilterPanelProps {
 
 export default function FilterPanel({ onFiltersChange }: FilterPanelProps) {
   const [filters, setFilters] = useState({
-    status: [] as string[],
+    phase: [] as string[],
     region: "",
     drivingLicense: [] as string[],
     dateFrom: "",
@@ -33,9 +33,9 @@ export default function FilterPanel({ onFiltersChange }: FilterPanelProps) {
     queryKey: ["/api/candidates"],
   });
 
-  const getStatusCount = (status: string) => {
+  const getPhaseCount = (phase: string) => {
     if (!Array.isArray(allCandidates)) return 0;
-    return (allCandidates as any[]).filter((candidate: any) => candidate.status === status).length;
+    return (allCandidates as any[]).filter((candidate: any) => candidate.phase === phase).length;
   };
 
   const getDrivingLicenseCount = (license: string) => {
@@ -45,12 +45,12 @@ export default function FilterPanel({ onFiltersChange }: FilterPanelProps) {
     ).length;
   };
 
-  const handleStatusChange = (status: string, checked: boolean) => {
-    const newStatus = checked
-      ? [...filters.status, status]
-      : filters.status.filter(s => s !== status);
-    
-    const newFilters = { ...filters, status: newStatus };
+  const handlePhaseChange = (phase: string, checked: boolean) => {
+    const newPhase = checked
+      ? [...filters.phase, phase]
+      : filters.phase.filter(s => s !== phase);
+
+    const newFilters = { ...filters, phase: newPhase };
     setFilters(newFilters);
     onFiltersChange(newFilters);
   };
@@ -79,7 +79,7 @@ export default function FilterPanel({ onFiltersChange }: FilterPanelProps) {
 
   const clearFilters = () => {
     const clearedFilters = {
-      status: [],
+      phase: [],
       region: "",
       drivingLicense: [],
       dateFrom: "",
@@ -96,27 +96,27 @@ export default function FilterPanel({ onFiltersChange }: FilterPanelProps) {
       <div className="flex-1 space-y-4 sm:space-y-6 min-h-0 overflow-y-auto">
         {/* Status Filter */}
         <div className="flex-shrink-0">
-          <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">Status</Label>
+          <Label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 block">Fase</Label>
           <div className="space-y-1 sm:space-y-2">
             {[
-              { value: "active", label: "Actief" },
+              { value: "intake", label: "Intake" },
+              { value: "matching", label: "Matching" },
               { value: "placed", label: "Geplaatst" },
-              { value: "inactive", label: "Inactief" },
-            ].map((status) => (
-              <div key={status.value} className="flex items-center justify-between min-w-0">
+            ].map((phase) => (
+              <div key={phase.value} className="flex items-center justify-between min-w-0">
                 <div className="flex items-center space-x-2 min-w-0 flex-1">
                   <Checkbox
-                    id={status.value}
-                    checked={filters.status.includes(status.value)}
-                    onCheckedChange={(checked) => handleStatusChange(status.value, checked as boolean)}
+                    id={phase.value}
+                    checked={filters.phase.includes(phase.value)}
+                    onCheckedChange={(checked) => handlePhaseChange(phase.value, checked as boolean)}
                     className="flex-shrink-0"
                   />
-                  <Label htmlFor={status.value} className="text-xs sm:text-sm text-gray-700 dark:text-gray-300 truncate">
-                    {status.label}
+                  <Label htmlFor={phase.value} className="text-xs sm:text-sm text-gray-700 dark:text-gray-300 truncate">
+                    {phase.label}
                   </Label>
                 </div>
                 <Badge variant="secondary" className="text-xs ml-2 flex-shrink-0">
-                  {getStatusCount(status.value)}
+                  {getPhaseCount(phase.value)}
                 </Badge>
               </div>
             ))}

--- a/client/src/components/NewCandidateModal.tsx
+++ b/client/src/components/NewCandidateModal.tsx
@@ -75,7 +75,6 @@ export default function NewCandidateModal({ isOpen, onClose }: NewCandidateModal
       ...data,
       drivingLicenses: drivingLicenses,
     } as any;
-    delete candidateData.status;
     createCandidateMutation.mutate(candidateData);
   };
 
@@ -158,13 +157,13 @@ export default function NewCandidateModal({ isOpen, onClose }: NewCandidateModal
             </Select>
           </div>
           <div>
-            <Label htmlFor="phase">Status</Label>
+            <Label htmlFor="phase">Fase</Label>
             <Select
               value={form.watch("phase")}
               onValueChange={(value) => form.setValue("phase", value)}
             >
               <SelectTrigger className="mt-1">
-                <SelectValue placeholder="Selecteer status" />
+                <SelectValue placeholder="Selecteer fase" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="intake">Intake</SelectItem>

--- a/client/src/components/candidate-form.tsx
+++ b/client/src/components/candidate-form.tsx
@@ -147,7 +147,6 @@ export default function CandidateForm({ candidate, onClose, onSuccess }: Candida
       marketing: data.marketing || null,
       description: data.description || null,
     };
-    delete cleanedData.status;
 
     if (isEditing) {
       updateMutation.mutate(cleanedData);

--- a/client/src/components/candidates-view-responsive.tsx
+++ b/client/src/components/candidates-view-responsive.tsx
@@ -38,8 +38,8 @@ export default function CandidatesView() {
       candidate.email?.toLowerCase().includes(filters.search.toLowerCase()) ||
       candidate.city?.toLowerCase().includes(filters.search.toLowerCase());
 
-    // Status filter
-    const matchesStatus = filters.selectedStatuses.length === 0 || filters.selectedStatuses.includes(candidate.status);
+    // Phase filter
+    const matchesPhase = filters.selectedPhases.length === 0 || filters.selectedPhases.includes(candidate.phase);
 
     // Region filter
     const matchesRegion = filters.selectedRegion === "" || filters.selectedRegion === "alle" || candidate.region === filters.selectedRegion;
@@ -50,7 +50,7 @@ export default function CandidatesView() {
         candidate.drivingLicenses.includes(license)
       ));
 
-    return matchesSearch && matchesStatus && matchesRegion && matchesLicense;
+    return matchesSearch && matchesPhase && matchesRegion && matchesLicense;
   }).sort((a: any, b: any) => {
     let aValue, bValue;
     
@@ -70,7 +70,7 @@ export default function CandidatesView() {
   });
 
   // Extract filter options from data
-  const statusOptions = Array.from(new Set(candidatesArray.map((c: any) => c.status).filter(Boolean)));
+  const phaseOptions = Array.from(new Set(candidatesArray.map((c: any) => c.phase).filter(Boolean)));
   const regionOptions = Array.from(new Set(candidatesArray.map((c: any) => c.region).filter(Boolean)));
   const licenseOptions = ['A', 'AM', 'B', 'BE', 'C', 'CE', 'D', 'DE', 'T'];
 
@@ -82,8 +82,8 @@ export default function CandidatesView() {
     }
   };
 
-  const activeFiltersCount = 
-    filters.selectedStatuses.length + 
+  const activeFiltersCount =
+    filters.selectedPhases.length +
     (filters.selectedRegion ? 1 : 0) + 
     filters.selectedLicenses.length +
     (filters.search ? 1 : 0);
@@ -232,17 +232,17 @@ export default function CandidatesView() {
       <div className="flex-1 p-2 sm:p-6 overflow-y-auto max-w-full">
         {/* Collapsible Filters */}
         <CollapsibleFilters
-          statusOptions={statusOptions}
+          phaseOptions={phaseOptions}
           regionOptions={regionOptions}
           licenseOptions={licenseOptions}
-          selectedStatuses={filters.selectedStatuses}
+          selectedPhases={filters.selectedPhases}
           selectedRegion={filters.selectedRegion}
           selectedLicenses={filters.selectedLicenses}
           dateFrom=""
           dateTo=""
           sortBy={filters.sortBy}
           sortOrder={filters.sortOrder}
-          onStatusChange={(statuses) => updateFilters({ selectedStatuses: statuses })}
+          onPhaseChange={(phases) => updateFilters({ selectedPhases: phases })}
           onRegionChange={(region) => updateFilters({ selectedRegion: region })}
           onLicenseChange={(licenses) => updateFilters({ selectedLicenses: licenses })}
           onDateFromChange={() => {}}

--- a/client/src/components/candidates-view.tsx
+++ b/client/src/components/candidates-view.tsx
@@ -12,7 +12,7 @@ import CompactList from "./compact-list";
 
 export default function CandidatesView() {
   const [search, setSearch] = useState("");
-  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(["active"]);
+  const [selectedPhases, setSelectedPhases] = useState<string[]>(["intake"]);
   const [selectedRegion, setSelectedRegion] = useState("");
   const [selectedLicenses, setSelectedLicenses] = useState<string[]>([]);
   const [dateFrom, setDateFrom] = useState("");
@@ -41,8 +41,8 @@ export default function CandidatesView() {
       candidate.email?.toLowerCase().includes(search.toLowerCase()) ||
       candidate.city?.toLowerCase().includes(search.toLowerCase());
 
-    // Status filter
-    const matchesStatus = selectedStatuses.length === 0 || selectedStatuses.includes(candidate.status);
+    // Phase filter
+    const matchesPhase = selectedPhases.length === 0 || selectedPhases.includes(candidate.phase);
 
     // Region filter
     const matchesRegion = selectedRegion === "" || selectedRegion === "alle" || candidate.region === selectedRegion;
@@ -65,7 +65,7 @@ export default function CandidatesView() {
       return true;
     })();
 
-    return matchesSearch && matchesStatus && matchesRegion && matchesLicense && matchesDate;
+    return matchesSearch && matchesPhase && matchesRegion && matchesLicense && matchesDate;
   }).sort((a: any, b: any) => {
     let aValue, bValue;
     
@@ -122,20 +122,13 @@ export default function CandidatesView() {
 
   const clearFilters = () => {
     setSearch("");
-    setSelectedStatuses([]);
+    setSelectedPhases([]);
     setSelectedRegion("");
     setSelectedLicenses([]);
     setDateFrom("");
     setDateTo("");
   };
 
-  const handleStatusChange = (status: string, checked: boolean) => {
-    if (checked) {
-      setSelectedStatuses([...selectedStatuses, status]);
-    } else {
-      setSelectedStatuses(selectedStatuses.filter(s => s !== status));
-    }
-  };
 
   const handleLicenseChange = (license: string, checked: boolean) => {
     if (checked) {
@@ -212,20 +205,20 @@ export default function CandidatesView() {
   }
 
   // Extract filter options from data
-  const statusSet = new Set<string>();
+  const phaseSet = new Set<string>();
   const regionSet = new Set<string>();
-  
+
   candidatesArray.forEach((c: any) => {
-    if (c.status) statusSet.add(c.status);
+    if (c.phase) phaseSet.add(c.phase);
     if (c.region) regionSet.add(c.region);
   });
-  
-  const statusOptions = Array.from(statusSet);
+
+  const phaseOptions = Array.from(phaseSet);
   const regionOptions = Array.from(regionSet);
   const licenseOptions = ['A', 'AM', 'B', 'BE', 'C', 'CE', 'D', 'DE', 'T'];
 
   const activeFiltersCount = 
-    selectedStatuses.length + 
+    selectedPhases.length +
     (selectedRegion ? 1 : 0) + 
     selectedLicenses.length +
     (dateFrom ? 1 : 0) +
@@ -291,17 +284,17 @@ export default function CandidatesView() {
       <div className="flex-1 p-4 sm:p-6 overflow-y-auto relative">
         {/* Collapsible Filters */}
         <CollapsibleFilters
-          statusOptions={statusOptions}
+          phaseOptions={phaseOptions}
           regionOptions={regionOptions}
           licenseOptions={licenseOptions}
-          selectedStatuses={selectedStatuses}
+          selectedPhases={selectedPhases}
           selectedRegion={selectedRegion}
           selectedLicenses={selectedLicenses}
           dateFrom={dateFrom}
           dateTo={dateTo}
           sortBy={sortBy}
           sortOrder={sortOrder}
-          onStatusChange={setSelectedStatuses}
+          onPhaseChange={setSelectedPhases}
           onRegionChange={setSelectedRegion}
           onLicenseChange={setSelectedLicenses}
           onDateFromChange={setDateFrom}

--- a/client/src/components/collapsible-filters.tsx
+++ b/client/src/components/collapsible-filters.tsx
@@ -10,17 +10,17 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 interface CollapsibleFiltersProps {
-  statusOptions: string[];
+  phaseOptions: string[];
   regionOptions: string[];
   licenseOptions: string[];
-  selectedStatuses: string[];
+  selectedPhases: string[];
   selectedRegion: string;
   selectedLicenses: string[];
   dateFrom: string;
   dateTo: string;
   sortBy: 'created' | 'updated';
   sortOrder: "asc" | "desc";
-  onStatusChange: (statuses: string[]) => void;
+  onPhaseChange: (phases: string[]) => void;
   onRegionChange: (region: string) => void;
   onLicenseChange: (licenses: string[]) => void;
   onDateFromChange: (date: string) => void;
@@ -30,17 +30,17 @@ interface CollapsibleFiltersProps {
 }
 
 export default function CollapsibleFilters({
-  statusOptions,
+  phaseOptions,
   regionOptions,
   licenseOptions,
-  selectedStatuses,
+  selectedPhases,
   selectedRegion,
   selectedLicenses,
   dateFrom,
   dateTo,
   sortBy,
   sortOrder,
-  onStatusChange,
+  onPhaseChange,
   onRegionChange,
   onLicenseChange,
   onDateFromChange,
@@ -83,28 +83,28 @@ export default function CollapsibleFilters({
       >
         <Card className="shadow-lg border-2">
           <CardContent className="p-4 space-y-4">
-            {/* Status Filter */}
+            {/* Phase Filter */}
             <div className="space-y-2">
-              <Label className="text-sm font-medium">Status</Label>
+              <Label className="text-sm font-medium">Fase</Label>
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                {statusOptions.map((status) => (
-                  <div key={status} className="flex items-center space-x-2">
+                {phaseOptions.map((phase) => (
+                  <div key={phase} className="flex items-center space-x-2">
                     <Checkbox
-                      id={`status-${status}`}
-                      checked={selectedStatuses.includes(status)}
+                      id={`phase-${phase}`}
+                      checked={selectedPhases.includes(phase)}
                       onCheckedChange={(checked) => {
                         if (checked) {
-                          onStatusChange([...selectedStatuses, status]);
+                          onPhaseChange([...selectedPhases, phase]);
                         } else {
-                          onStatusChange(selectedStatuses.filter(s => s !== status));
+                          onPhaseChange(selectedPhases.filter(s => s !== phase));
                         }
                       }}
                     />
                     <Label
-                      htmlFor={`status-${status}`}
+                      htmlFor={`phase-${phase}`}
                       className="text-sm capitalize cursor-pointer"
                     >
-                      {status}
+                      {phase}
                     </Label>
                   </div>
                 ))}

--- a/client/src/components/compact-list.tsx
+++ b/client/src/components/compact-list.tsx
@@ -51,13 +51,10 @@ export default function CompactList({ items, type, onView, onEdit, isLoading }: 
     const statusKey = status?.toLowerCase().replace(/\s+/g, '-');
     
     const colors = {
-      // Candidate statuses
-      'nieuw': "status-badge status-nieuw",
-      'beschikbaar': "status-badge status-beschikbaar",
-      'in-bemiddeling': "status-badge status-in-bemiddeling",
-      'werkend': "status-badge status-werkend",
-      'nu-niet-beschikbaar': "status-badge status-nu-niet-beschikbaar",
-      'inactief': "status-badge status-inactief",
+      // Candidate phases
+      'intake': "status-badge status-intake",
+      'matching': "status-badge status-matching",
+      'placed': "status-badge status-placed",
       
       // Trajectory statuses
       'geaccepteerd': "status-badge status-geaccepteerd",
@@ -92,13 +89,10 @@ export default function CompactList({ items, type, onView, onEdit, isLoading }: 
 
   const getStatusLabel = (status: string) => {
     const labels = {
-      // Candidate statuses
-      nieuw: "Nieuw",
-      beschikbaar: "Beschikbaar",
-      'in-bemiddeling': "In bemiddeling",
-      werkend: "Werkend",
-      'nu-niet-beschikbaar': "Nu niet beschikbaar",
-      inactief: "Inactief",
+      // Candidate phases
+      intake: "Intake",
+      matching: "Matching",
+      placed: "Geplaatst",
       
       // Trajectory statuses
       geaccepteerd: "Geaccepteerd",
@@ -140,8 +134,8 @@ export default function CompactList({ items, type, onView, onEdit, isLoading }: 
                 <h3 className="font-medium text-sm sm:text-base text-gray-900 dark:text-white truncate min-w-0">
                   {candidate.name}
                 </h3>
-                <span className={`${getStatusColor(candidate.status)} shrink-0`}>
-                  {getStatusLabel(candidate.status)}
+                <span className={`${getStatusColor(candidate.phase)} shrink-0`}>
+                  {getStatusLabel(candidate.phase)}
                 </span>
               </div>
               

--- a/client/src/components/trajectory-form.tsx
+++ b/client/src/components/trajectory-form.tsx
@@ -13,12 +13,12 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
-import { 
+import {
   validateTrajectoryData,
   getTrajectoryStatusOptions,
-  getCandidateStatusOptions,
-  getSuggestedCandidateStatus,
-  formatCandidateStatus
+  getCandidatePhaseOptions,
+  getSuggestedCandidatePhase,
+  formatCandidatePhase
 } from "@/lib/trajectory-formatters";
 import type { TrajectoryWithRelations, Candidate, Client } from "@shared/schema";
 
@@ -27,7 +27,7 @@ const trajectoryFormSchema = z.object({
   clientId: z.number().min(1, "Selecteer een opdrachtgever"),
   jobTitle: z.string().min(1, "Functietitel is verplicht"),
   status: z.string().optional(),
-  candidateStatus: z.string().optional(),
+  candidatePhase: z.string().optional(),
   note: z.string().optional(),
 });
 
@@ -52,7 +52,7 @@ export default function TrajectoryForm({
 }: TrajectoryFormProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [showCandidateStatus, setShowCandidateStatus] = useState(false);
+  const [showCandidatePhase, setShowCandidatePhase] = useState(false);
   const [selectedCandidate, setSelectedCandidate] = useState<Candidate | null>(null);
 
   // Validate trajectory data when editing
@@ -64,7 +64,7 @@ export default function TrajectoryForm({
     clientId: trajectory?.clientId || 0,
     jobTitle: trajectory?.jobTitle || "",
     status: trajectory?.status || "geaccepteerd",
-    candidateStatus: "",
+    candidatePhase: "",
     note: "",
   };
 
@@ -102,7 +102,7 @@ export default function TrajectoryForm({
         clientId: trajectory.clientId || 0,
         jobTitle: trajectory.jobTitle || "",
         status: trajectory.status || "geaccepteerd",
-        candidateStatus: "",
+        candidatePhase: "",
         note: "",
       });
       
@@ -117,7 +117,7 @@ export default function TrajectoryForm({
         clientId: 0,
         jobTitle: "",
         status: "geaccepteerd",
-        candidateStatus: "",
+        candidatePhase: "",
         note: "",
       });
       if (candidateId && candidates.length > 0) {
@@ -126,7 +126,7 @@ export default function TrajectoryForm({
       } else {
         setSelectedCandidate(null);
       }
-      setShowCandidateStatus(false);
+      setShowCandidatePhase(false);
     }
   }, [trajectory, mode, form, toast, candidates, candidateId]);
 
@@ -162,15 +162,15 @@ export default function TrajectoryForm({
       
       const result = await response.json();
       
-      // Update candidate status if provided
-      if (data.candidateStatus && data.candidateId) {
+      // Update candidate phase if provided
+      if (data.candidatePhase && data.candidateId) {
         try {
           await apiRequest("PUT", `/api/candidates/${data.candidateId}`, {
-            status: data.candidateStatus
+            phase: data.candidatePhase
           });
         } catch (error) {
-          console.error("Failed to update candidate status:", error);
-          // Don't fail the trajectory update if candidate status update fails
+          console.error("Failed to update candidate phase:", error);
+          // Don't fail the trajectory update if candidate phase update fails
         }
       }
       
@@ -189,7 +189,7 @@ export default function TrajectoryForm({
       });
       
       form.reset();
-      setShowCandidateStatus(false);
+      setShowCandidatePhase(false);
       onClose();
       onSuccess?.();
     },
@@ -294,15 +294,15 @@ export default function TrajectoryForm({
                     value={field.value || ""} 
                     onValueChange={(value) => {
                       field.onChange(value);
-                      // Show candidate status selection when trajectory status changes
+                      // Show candidate phase selection when trajectory status changes
                       const candidateId = form.watch('candidateId');
                       if (value && candidateId && candidates.length > 0) {
                         const candidate = candidates.find((c: Candidate) => c.id === candidateId);
                         if (candidate) {
                           setSelectedCandidate(candidate);
-                          setShowCandidateStatus(true);
-                          const suggestedStatus = getSuggestedCandidateStatus(value);
-                          form.setValue('candidateStatus', suggestedStatus);
+                          setShowCandidatePhase(true);
+                          const suggestedPhase = getSuggestedCandidatePhase(value);
+                          form.setValue('candidatePhase', suggestedPhase);
                         }
                       }
                     }}
@@ -339,14 +339,14 @@ export default function TrajectoryForm({
                         const candidateId = value ? parseInt(value, 10) : 0;
                         field.onChange(candidateId);
 
-                        // Find selected candidate and show status selection if trajectory status is set
+                        // Find selected candidate and show phase selection if trajectory status is set
                         const candidate = candidates.find((c: Candidate) => c.id === candidateId);
                         setSelectedCandidate(candidate || null);
 
                         if (candidateId && form.watch('status')) {
-                          setShowCandidateStatus(true);
-                          const suggestedStatus = getSuggestedCandidateStatus(form.watch('status'));
-                          form.setValue('candidateStatus', suggestedStatus);
+                          setShowCandidatePhase(true);
+                          const suggestedPhase = getSuggestedCandidatePhase(form.watch('status'));
+                          form.setValue('candidatePhase', suggestedPhase);
                         }
                       }}
                     >
@@ -376,19 +376,19 @@ export default function TrajectoryForm({
               </div>
             )}
 
-            {/* Candidate Status Selection - shows when trajectory status changes */}
-            {showCandidateStatus && selectedCandidate && (
+            {/* Candidate Phase Selection - shows when trajectory status changes */}
+            {showCandidatePhase && selectedCandidate && (
               <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg space-y-3">
                 <Label className="text-sm font-medium">
-                  Wijzig status van kandidaat: {selectedCandidate.name}
+                  Wijzig fase van kandidaat: {selectedCandidate.name}
                 </Label>
                 <p className="text-xs text-gray-600 dark:text-gray-400">
-                  Huidige status: {formatCandidateStatus(selectedCandidate.status)}
+                  Huidige fase: {formatCandidatePhase(selectedCandidate.phase)}
                 </p>
-                
+
                 <FormField
                   control={form.control}
-                  name="candidateStatus"
+                  name="candidatePhase"
                   render={({ field }) => (
                     <FormItem>
                       <FormControl>
@@ -397,7 +397,7 @@ export default function TrajectoryForm({
                           onValueChange={field.onChange}
                           className="grid grid-cols-1 gap-2"
                         >
-                          {getCandidateStatusOptions().map((option) => (
+                          {getCandidatePhaseOptions().map((option) => (
                             <div key={option.value} className="flex items-center space-x-2">
                               <RadioGroupItem value={option.value} id={option.value} />
                               <Label htmlFor={option.value} className="text-sm cursor-pointer">

--- a/client/src/hooks/usePersistedFilters.ts
+++ b/client/src/hooks/usePersistedFilters.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
 export interface FilterState {
-  selectedStatuses: string[];
+  selectedPhases: string[];
   selectedRegion: string;
   selectedLicenses: string[];
   search: string;
@@ -10,7 +10,7 @@ export interface FilterState {
 }
 
 const DEFAULT_FILTERS: FilterState = {
-  selectedStatuses: [],
+  selectedPhases: [],
   selectedRegion: "",
   selectedLicenses: [],
   search: "",
@@ -58,8 +58,8 @@ export function usePersistedFilters(storageKey: string = "candidates-filters") {
 
   // Check if any filters are active
   const hasActiveFilters = () => {
-    return filters.selectedStatuses.length > 0 || 
-           filters.selectedRegion !== "" || 
+    return filters.selectedPhases.length > 0 ||
+           filters.selectedRegion !== "" ||
            filters.selectedLicenses.length > 0 ||
            filters.search !== "";
   };

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -91,7 +91,20 @@
   .status-badge {
     @apply inline-flex items-center px-3 py-1 rounded-full text-xs font-medium tracking-wide border;
   }
-  
+
+  /* Candidate Phases */
+  .status-intake {
+    @apply bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-900/20 dark:text-purple-400 dark:border-purple-800/50;
+  }
+
+  .status-matching {
+    @apply bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-800/50;
+  }
+
+  .status-placed {
+    @apply bg-emerald-100 text-emerald-800 border-emerald-300 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-700/50;
+  }
+
   /* Candidate Statuses */
   .status-nieuw {
     @apply bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-400 dark:border-emerald-800/50;

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -30,7 +30,7 @@ function getRequestHeaders() {
 export const candidateApi = {
   getAll: (filters?: {
     search?: string;
-    status?: string[];
+    phase?: string[];
     region?: string;
     drivingLicenses?: string[];
     dateFrom?: Date;
@@ -38,7 +38,7 @@ export const candidateApi = {
   }) => {
     const params = new URLSearchParams();
     if (filters?.search) params.append('search', filters.search);
-    if (filters?.status?.length) params.append('status', filters.status.join(','));
+    if (filters?.phase?.length) params.append('phase', filters.phase.join(','));
     if (filters?.region) params.append('region', filters.region);
     if (filters?.drivingLicenses?.length) params.append('drivingLicenses', filters.drivingLicenses.join(','));
     if (filters?.dateFrom) params.append('dateFrom', filters.dateFrom.toISOString());

--- a/client/src/lib/trajectory-formatters.ts
+++ b/client/src/lib/trajectory-formatters.ts
@@ -92,57 +92,48 @@ export const getTrajectorySubtitle = (trajectory: TrajectoryWithRelations): stri
   return `${candidateName} bij ${clientName}`;
 };
 
-// Candidate status formatters
-export const formatCandidateStatus = (status: string | null): string => {
-  if (!status) return "Onbekend";
-  
-  const statusLabels = {
-    nieuw: "Nieuw",
-    beschikbaar: "Beschikbaar",
-    in_bemiddeling: "In bemiddeling",
-    werkend: "Werkend",
-    nu_niet_beschikbaar: "Nu niet beschikbaar",
-    inactief: "Inactief"
+// Candidate phase formatters
+export const formatCandidatePhase = (phase: string | null): string => {
+  if (!phase) return "Onbekend";
+
+  const phaseLabels = {
+    intake: "Intake",
+    matching: "Matching",
+    placed: "Geplaatst",
   };
-  
-  return statusLabels[status as keyof typeof statusLabels] || status;
+
+  return phaseLabels[phase as keyof typeof phaseLabels] || phase;
 };
 
-export const getCandidateStatusColor = (status: string | null): string => {
-  const statusColors = {
-    nieuw: "bg-purple-600",
-    beschikbaar: "bg-green-600",
-    in_bemiddeling: "bg-blue-600",
-    werkend: "bg-indigo-600",
-    nu_niet_beschikbaar: "bg-orange-600",
-    inactief: "bg-gray-600"
+export const getCandidatePhaseColor = (phase: string | null): string => {
+  const phaseColors = {
+    intake: "bg-purple-600",
+    matching: "bg-amber-600",
+    placed: "bg-green-600",
   };
-  
-  return statusColors[status?.toLowerCase() as keyof typeof statusColors] || "bg-gray-600";
+
+  return phaseColors[phase?.toLowerCase() as keyof typeof phaseColors] || "bg-gray-600";
 };
 
-// Get suggested candidate status based on trajectory status
-export const getSuggestedCandidateStatus = (trajectoryStatus: string | null): string => {
-  const statusMapping = {
-    geaccepteerd: "in_bemiddeling",
-    voorgesteld_aan_klant: "in_bemiddeling",
-    gesprek_met_klant: "in_bemiddeling",
-    geplaatst: "werkend",
-    niet_geplaatst: "beschikbaar",
-    gestopt: "beschikbaar"
+// Get suggested candidate phase based on trajectory status
+export const getSuggestedCandidatePhase = (trajectoryStatus: string | null): string => {
+  const phaseMapping = {
+    geaccepteerd: "matching",
+    voorgesteld_aan_klant: "matching",
+    gesprek_met_klant: "matching",
+    geplaatst: "placed",
+    niet_geplaatst: "intake",
+    gestopt: "intake",
   };
-  
-  return statusMapping[trajectoryStatus as keyof typeof statusMapping] || "beschikbaar";
+
+  return phaseMapping[trajectoryStatus as keyof typeof phaseMapping] || "intake";
 };
 
-// Get all candidate status options in order
-export const getCandidateStatusOptions = () => [
-  { value: "nieuw", label: "Nieuw" },
-  { value: "beschikbaar", label: "Beschikbaar" },
-  { value: "in_bemiddeling", label: "In bemiddeling" },
-  { value: "werkend", label: "Werkend" },
-  { value: "nu_niet_beschikbaar", label: "Nu niet beschikbaar" },
-  { value: "inactief", label: "Inactief" }
+// Get all candidate phase options in order
+export const getCandidatePhaseOptions = () => [
+  { value: "intake", label: "Intake" },
+  { value: "matching", label: "Matching" },
+  { value: "placed", label: "Geplaatst" },
 ];
 
 // Get all trajectory status options

--- a/client/src/pages/candidate-detail.tsx
+++ b/client/src/pages/candidate-detail.tsx
@@ -133,12 +133,16 @@ export default function CandidateDetail() {
     });
   };
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "active": return "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400";
-      case "placed": return "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400";
-      case "inactive": return "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400";
-      default: return "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400";
+  const getStatusColor = (phase: string) => {
+    switch (phase) {
+      case "intake":
+        return "bg-purple-100 text-purple-800 dark:bg-purple-900/20 dark:text-purple-400";
+      case "matching":
+        return "bg-amber-100 text-amber-800 dark:bg-amber-900/20 dark:text-amber-400";
+      case "placed":
+        return "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400";
+      default:
+        return "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400";
     }
   };
 
@@ -299,26 +303,18 @@ export default function CandidateDetail() {
           <div className="space-y-6">
             <Card>
               <CardHeader>
-                <CardTitle>Status & Fase</CardTitle>
+                <CardTitle>Fase</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div>
                   <Label className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                    Status
-                  </Label>
-                  <div className="mt-1">
-                    <Badge className={getStatusColor(candidate.status || "")}>
-                      {candidate.status || "Onbekend"}
-                    </Badge>
-                  </div>
-                </div>
-                <div>
-                  <Label className="text-sm font-medium text-gray-500 dark:text-gray-400">
                     Fase
                   </Label>
-                  <p className="mt-1 text-sm text-gray-900 dark:text-white">
-                    {candidate.phase || "-"}
-                  </p>
+                  <div className="mt-1">
+                    <Badge className={getStatusColor(candidate.phase || "")}>
+                      {candidate.phase || "Onbekend"}
+                    </Badge>
+                  </div>
                 </div>
                 <div>
                   <Label className="text-sm font-medium text-gray-500 dark:text-gray-400">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -599,7 +599,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const filters = {
         search: req.query.search as string,
-        status: req.query.status ? (req.query.status as string).split(',') : undefined,
+        phase: req.query.phase ? (req.query.phase as string).split(',') : undefined,
         region: req.query.region as string,
         drivingLicenses: req.query.drivingLicenses ? (req.query.drivingLicenses as string).split(',') : undefined,
         dateFrom: req.query.dateFrom ? new Date(req.query.dateFrom as string) : undefined,
@@ -830,7 +830,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             phone: String(rowData.Telefoonnummer || rowData.telefoon || rowData.Phone || rowData.TELEFOON || '').trim() || null,
             city: String(rowData.Woonplaats || rowData.stad || rowData.City || rowData.STAD || '').trim() || null,
             region: String(rowData.Regio || rowData.regio || rowData.Region || rowData.REGIO || '').trim() || null,
-            status: String(rowData.Status || rowData.status || rowData.STATUS || 'active').trim(),
+            phase: String(rowData.Phase || rowData.phase || rowData.PHASE || 'intake').trim(),
             drivingLicenses: (() => {
               const rawLicense = rowData.Rijbewijs || rowData.rijbewijs || rowData['Rijbewijs type'] || rowData['Rijbewijzen'] || '';
               if (!rawLicense) return [];

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -62,7 +62,7 @@ export interface IStorage {
   // Candidate operations
   getCandidates(filters?: {
     search?: string;
-    status?: string[];
+    phase?: string[];
     region?: string;
     drivingLicenses?: string[];
     dateFrom?: Date;
@@ -254,7 +254,7 @@ export class DatabaseStorage implements IStorage {
   // Candidate operations
   async getCandidates(filters?: {
     search?: string;
-    status?: string[];
+    phase?: string[];
     region?: string;
     drivingLicenses?: string[];
     dateFrom?: Date;
@@ -286,8 +286,8 @@ export class DatabaseStorage implements IStorage {
       );
     }
 
-    if (filters?.status?.length) {
-      conditions.push(eq(candidates.status, filters.status[0])); // Simplified for now
+    if (filters?.phase?.length) {
+      conditions.push(eq(candidates.phase, filters.phase[0])); // Simplified for now
     }
 
     if (filters?.region) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -257,7 +257,6 @@ export const insertCandidateSchema = createInsertSchema(candidates).omit({
   email: z.string().email("Ongeldig e-mailadres").optional().nullable(),
   dateAdded: z.date().optional().nullable(),
   region: z.string().optional().nullable(),
-  status: z.string().optional().nullable(),
   description: z.string().optional().nullable(),
   drivingLicenses: z.array(z.string()).optional().nullable(),
   drivingLicenseNotes: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary
- Switch candidate filtering from `status` to `phase` on the server and API
- Update hooks, components, and styles to display candidate phase values
- Introduce phase utilities for trajectories and remove status references

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a886d2994c832d8ff3fda5b10acb87